### PR TITLE
details and note about duplicate method

### DIFF
--- a/weilrep/amf.py
+++ b/weilrep/amf.py
@@ -517,7 +517,7 @@ class AlgebraicModularForms:
         - ``X`` -- an integer, OR a list of AlgebraicModularForm instances
         - ``spin`` -- an integer dividing self's determinant
         - ``det`` -- either 1 or -1
-        - ``dimension_bound" -- a natural number (only eigenforms over fields of degree at most this will be found) default None
+        - ``dimension_bound`` -- a natural number (only eigenforms over fields of degree at most this will be found) default ``None``
 
         EXAMPLES::
 

--- a/weilrep/eisenstein_series.py
+++ b/weilrep/eisenstein_series.py
@@ -259,7 +259,6 @@ def local_normal_form_with_change_vars(S, p):
         [-1  2]
         )
     """
-    #
     Q = QuadraticForm(S)
     I = list(range(Q.dim()))
     M = identity_matrix(QQ, Q.dim())

--- a/weilrep/jacobi_forms_class.py
+++ b/weilrep/jacobi_forms_class.py
@@ -1503,7 +1503,7 @@ class JacobiForm:
 
     def _rescale_q(self, a):
         from .jacobi_lvl import JacobiFormWithLevel
-        return JacobiFormWithLevel(self.weight(), 1, self.index_matrix(), self.qexp().V(a), q_scale = a, w_scale = self.scale())
+        return JacobiFormWithLevel(self.weight(), 1, self.index_matrix(), self.qexp().V(a), q_scale=a, w_scale=self.scale())
 
     def scale(self):
         return self.__wscale

--- a/weilrep/mock.py
+++ b/weilrep/mock.py
@@ -42,7 +42,6 @@ from sage.symbolic.constants import pi
 from .weilrep_modular_forms_class import WeilRepModularForm, WeilRepModularFormsBasis, WeilRepModularFormWithCharacter
 
 
-
 class WeilRepQuasiModularForm(WeilRepModularForm):
     r"""
     Class for quasimodular forms.

--- a/weilrep/paramodular.py
+++ b/weilrep/paramodular.py
@@ -124,6 +124,7 @@ class ParamodularForms(OrthogonalModularFormsPositiveDefinite):
 class ParamodularForm(OrthogonalModularFormPositiveDefinite):
 
     def level(self):
+        # should this use // 2 instead ?
         return Integer(self.gram_matrix()[0, 0] / 2)
 
     def __getitem__(self, a):
@@ -282,9 +283,6 @@ class ParamodularForm(OrthogonalModularFormPositiveDefinite):
                             break
         h = h.add_bigoh(bound)
         return OrthogonalModularForm(k, self.weilrep(), h, 1, vector([0] * 3), qexp_representation='siegel')
-
-    def level(self):
-        return self.gram_matrix()[0, 0] / 2
 
     def level_raising_operator_1(self, m):
         r"""

--- a/weilrep/weilrep.py
+++ b/weilrep/weilrep.py
@@ -4292,8 +4292,7 @@ class WeilRep:
         try:
             _, N = self._flag()
             sturm_bound *= N
-            if sturm_bound < 0:
-                sturm_bound = 0
+            sturm_bound = max(sturm_bound, 0)
         except (AttributeError, TypeError):
             pass
         prec = max(prec, sturm_bound)

--- a/weilrep/weilrep_modular_forms_class.py
+++ b/weilrep/weilrep_modular_forms_class.py
@@ -1316,25 +1316,6 @@ class WeilRepModularForm:
         f = WeilRepQuasiModularForm(k + 2, S, [-k * self, d(self)], weilrep=self.weilrep())
         return f
 
-    def eigenvalue(self, N):
-        r"""
-        Compute self's Hecke eigenvalue with respect to the operator T_N.
-
-        This will return a ValueError if self is not an eigenvector of T_N.
-
-        NOTE: In some conventions T_N is known as T_{N^2}.
-        """
-        from .weilrep_misc import relations
-        V = relations(self.hecke_T(N), self).basis_matrix()
-        if V.nrows():
-            if V.nrows() > 1:
-                raise ValueError
-            a, b = V.rows()[0]
-            if b:
-                return -b/a
-            raise ValueError('Insufficient precision')
-        raise ValueError('This is not an eigenform')
-
     def hecke_P(self, N):
         r"""
         Apply the Nth Hecke projection map.
@@ -1745,16 +1726,37 @@ class WeilRepModularForm:
 
     def eigenvalue(self, p):
         r"""
+        Compute self's Hecke eigenvalue with respect to the operator T_p.
+
+        This will return a ValueError if self is not an eigenvector of T_p.
+
+        NOTE: In some conventions T_p is known as T_{p^2}.
+        """
+        from .weilrep_misc import relations
+        V = relations(self.hecke_T(p), self).basis_matrix()
+        if V.nrows():
+            if V.nrows() > 1:
+                raise ValueError
+            a, b = V.rows()[0]
+            if b:
+                return -b / a
+            raise ValueError('Insufficient precision')
+        raise ValueError('This is not an eigenform')
+
+    def eigenvalue(self, p):
+        r"""
         Compute self's eigenvalue at a prime p.
+
+        DUPLICATE OF PREVIOUS METHOD, MERGE !
         """
         from .weilrep_misc import relations
         V = relations(self.hecke_T(p), self).basis_matrix()
         if not V.nrows():
-            raise ValueError('This form is not an eigenvalue of T_{%s}' % p)
+            raise ValueError(f'This form is not an eigenform of T_{p}')
         elif V.nrows() != 1:
             raise ValueError('Insufficient precision')
-        v, = V.rows()
-        return -(v[1] / v[0])
+        (a, b), = V.rows()
+        return -b / a
 
     def euler_factor(self, p):
         m = self.weilrep().level()
@@ -2170,7 +2172,7 @@ class WeilRepModularForm:
             [(1/8), O(q^(81/16))]
         """
         S = self.gram_matrix()
-        if not (b * S * b / 2) in ZZ:
+        if (b * S * b / 2) not in ZZ:
             raise ValueError('Nonzero norm vector in method .symmetrized()')
         d_b = denominator(b)
         if d_b == 1:

--- a/weilrep/weilrep_modular_forms_class.py
+++ b/weilrep/weilrep_modular_forms_class.py
@@ -1734,28 +1734,13 @@ class WeilRepModularForm:
         """
         from .weilrep_misc import relations
         V = relations(self.hecke_T(p), self).basis_matrix()
-        if V.nrows():
-            if V.nrows() > 1:
-                raise ValueError
-            a, b = V.rows()[0]
-            if b:
-                return -b / a
-            raise ValueError('Insufficient precision')
-        raise ValueError('This is not an eigenform')
-
-    def eigenvalue(self, p):
-        r"""
-        Compute self's eigenvalue at a prime p.
-
-        DUPLICATE OF PREVIOUS METHOD, MERGE !
-        """
-        from .weilrep_misc import relations
-        V = relations(self.hecke_T(p), self).basis_matrix()
         if not V.nrows():
             raise ValueError(f'This form is not an eigenform of T_{p}')
         elif V.nrows() != 1:
             raise ValueError('Insufficient precision')
         (a, b), = V.rows()
+        if not a:
+            raise ValueError('Insufficient precision')
         return -b / a
 
     def euler_factor(self, p):


### PR DESCRIPTION
make sure that the code fits the current sagemath conventions (rst, pycodestyle, ruff)

remove one duplicate method

move another duplicate method towards its copy, to let you choose among them
